### PR TITLE
Configure backend via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Environment configuration for MiKan backend
+DB_USER=postgres
+DB_PASSWORD=password
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=mikan_db
+# DB_URL can override the above settings completely
+# DB_URL=postgresql://user:pass@host:5432/dbname
+LOGIN_DATABASE_URL=postgresql://postgres:password@localhost/Logindatabase
+# Base URL used when generating links to attachments
+ATTACHMENT_BASE_URL=http://localhost:8000

--- a/backend/Loginpage/Loginpage.py
+++ b/backend/Loginpage/Loginpage.py
@@ -6,12 +6,18 @@ from typing import Optional
 
 from databases import Database
 from sqlalchemy import Table, Column, String, MetaData
+import os
+from dotenv import load_dotenv
 
 # -------------------- Database Setup -------------------- #
-# Please open your pgAdmin and RESTORE the file Logindatabase into you pfAdmin database #
-# Default database name is Logindatabase and password is password #
+# Please open your pgAdmin and RESTORE the file Logindatabase into your pgAdmin database
+# Default database name is Logindatabase and password is password
 
-DATABASE_URL = "postgresql://postgres:password@localhost/Logindatabase"
+load_dotenv()
+DATABASE_URL = os.getenv(
+    "LOGIN_DATABASE_URL",
+    "postgresql://postgres:password@localhost/Logindatabase",
+)
 database = Database(DATABASE_URL)
 metadata = MetaData()
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,12 +1,22 @@
 from sqlalchemy import *
 from sqlalchemy.orm import *
+import os
+from dotenv import load_dotenv
 
-DB_USER = "postgres"
-DB_PASSWORD = "password"
-DB_HOST = "localhost"
-DB_PORT = 5432
-DB_NAME = "mikan_db"
-DB_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+# Load environment variables from a .env file if present
+load_dotenv()
+
+DB_USER = os.getenv("DB_USER", "postgres")
+DB_PASSWORD = os.getenv("DB_PASSWORD", "password")
+DB_HOST = os.getenv("DB_HOST", "localhost")
+DB_PORT = int(os.getenv("DB_PORT", "5432"))
+DB_NAME = os.getenv("DB_NAME", "mikan_db")
+
+# Allow providing full database URL via environment variable
+DB_URL = os.getenv(
+    "DB_URL",
+    f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+)
 
 engine = create_engine(DB_URL)
 Base = declarative_base()

--- a/backend/routers/boards.py
+++ b/backend/routers/boards.py
@@ -1,6 +1,10 @@
 from fastapi import *
 from database import *
 from model import *
+import os
+
+# Base URL for constructing links to attachments
+ATTACHMENT_BASE_URL = os.getenv("ATTACHMENT_BASE_URL", "http://localhost:8000")
 
 router = APIRouter()
 db_dependency = Annotated[Session, Depends(get_db)]
@@ -106,10 +110,10 @@ def get_project_boards(db: db_dependency):
 
             if row["attachment_id"]:
                 task_tracker[task_id]["attachments"].append({
-					"name": row["attachment_name"],
-					"url": f"http://127.0.0.1:8000/attachments/download_file/{row['attachment_id']}",
-					"type": "link"
-				})
+                    "name": row["attachment_name"],
+                    "url": f"{ATTACHMENT_BASE_URL}/attachments/download_file/{row['attachment_id']}",
+                    "type": "link",
+                })
 
             if row["ai_attachment_name"]:
                 task_tracker[task_id]["ai_attachments"].append({


### PR DESCRIPTION
## Summary
- add example `.env` with backend config
- load environment variables for database settings
- allow configuring login DB and attachment URLs via environment variables

## Testing
- `python -m py_compile backend/database.py backend/Loginpage/Loginpage.py backend/routers/boards.py`
- `find backend -name '*.py' ! -path '*/__pycache__/*' -print | xargs python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_68789b28adc08326b6d49f1ec6fbde70